### PR TITLE
fix search bar alignment

### DIFF
--- a/styles/css/home/vtex.store-components.css
+++ b/styles/css/home/vtex.store-components.css
@@ -4,7 +4,6 @@
 
 .searchBarContainer :global(.vtex-input-prefix__group) {
   border-style: none;
-  max-width: 46rem;
   height: 64px;
 }
 


### PR DESCRIPTION
Search bar was with a max-width that would break the alignment, I moved the max-width to its parent.