### PR TITLE
Add a dialog for account redirection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Account dialog that redirects users to app install admin page
+
 ## [0.4.0] - 2020-07-01
 
 ### Added 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-
 - Account dialog that redirects users to app install admin page
 
 ## [0.4.0] - 2020-07-01

--- a/manifest.json
+++ b/manifest.json
@@ -45,11 +45,11 @@
     "vtex.iframe": "0.x",
     "vtex.breadcrumb": "1.x",
     "vtex.sticky-layout": "0.x",
-    "vtex.add-to-cart-button": "0.x",
     "vtex.store-link": "0.x",
     "vtex.seller-selector": "0.x",
     "vtex.reviews-and-ratings": "1.x",
-    "vtex.store-image": "0.x"
+    "vtex.store-image": "0.x",
+    "extensions.account-dialog": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/store/blocks/product/blocks/topBar.jsonc
+++ b/store/blocks/product/blocks/topBar.jsonc
@@ -112,7 +112,7 @@
     },
     "children": [
       "flex-layout.col#rating",
-      "add-to-cart-button"
+      "account-dialog"
     ]
   },
   "flex-layout.col#rating": {

--- a/styles/css/product/extensions.account-dialog.css
+++ b/styles/css/product/extensions.account-dialog.css
@@ -18,11 +18,11 @@
 
 .title {
   font-weight: 500;
-  font-size: 20px;
+  font-size: 1.25rem;
   line-height: 1.6;
   display: flex;
   align-items: center;
-  letter-spacing: -0.2px;
+  letter-spacing: -0.0125rem;
 }
 
 .modalContainer :global(.vtex-styleguide-9-x-scrollBar) {
@@ -34,7 +34,7 @@
 }
 
 .dialogAction {
-  font-size: 16px;
+  font-size: 1rem;
   line-height: 1.5;
   display: flex;
   align-items: center;

--- a/styles/css/product/extensions.account-dialog.css
+++ b/styles/css/product/extensions.account-dialog.css
@@ -1,0 +1,49 @@
+.modalContainer :global(.vtex-modal__overlay) {
+  background-color:rgba(63, 63, 64, 0.4) !important;
+}
+
+.modalContainer :global(.vtex-modal__modal) {
+  max-width: 40rem;
+}
+
+.modalContainer :global(.vtex-styleguide-9-x-shadowTransition) {
+  border-bottom: 1px solid #E3E4E6;
+  padding: 2rem;
+}
+
+.modalContainer :global(.vtex-modal__close-icon) {
+  position: relative;
+  padding: 0;
+}
+
+.title {
+  font-weight: 500;
+  font-size: 20px;
+  line-height: 1.6;
+  display: flex;
+  align-items: center;
+  letter-spacing: -0.2px;
+}
+
+.modalContainer :global(.vtex-styleguide-9-x-scrollBar) {
+  padding: 2rem;
+}
+
+.content {
+  padding: 0 0 2rem 0;
+}
+
+.dialogAction {
+  font-size: 16px;
+  line-height: 1.5;
+  display: flex;
+  align-items: center;
+}
+
+.dialogInput :global(.vtex-input-prefix__group) {
+  border: 2px solid #CACBCC;
+}
+
+.dialogInput :global(.vtex-styleguide-9-x-input) {
+  background-color: white;
+}


### PR DESCRIPTION
#### What problem is this solving?

Adds a mechanism to redirect the user to the admin page responsible for the app installation. This way, the user can complete his app order while we don't finish the new purchase experience

#### How should this be manually tested?

1. In this [linked workspace](https://newartur--extensions.myvtex.com/google-shopping/p), click on `Get App`
2. Fill the input and continue to your store by clicking `Continue` or hitting the **return** key

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/3827456/86952695-c15ae180-c129-11ea-91d2-56ef6136b597.png)

#### Type of changes

- [ ] Bug fix <!-- a non-breaking change which fixes an issue -->
- [x] New feature <!-- a non-breaking change which adds functionality -->
- [ ] Breaking change <!-- fix or feature that would cause existing functionality to change -->
- [ ] Refactoring <!-- chores, refactors and overall reduction of technical debt -->
