### PR TITLE
Update account dialog styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [0.21.3] - 2020-09-08
-
-## Removed
-
-- Highlights from all apps Page
-
-## [0.21.2] - 2020-09-08
-
-## Fixed
-
-- Links and padding of home page
-
-## [0.21.1] - 2020-09-08
+- Account dialog input style when errors occur
 
 ## [0.21.0] - 2020-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## Fixed	
+
 - Account dialog input style when errors occur
+
+## [0.21.3] - 2020-09-08	- Account dialog input style when errors occur
+
+## Removed	
+
+- Highlights from all apps Page	
+
+## [0.21.2] - 2020-09-08	
+
+## Fixed	
+
+- Links and padding of home page
 
 ## [0.21.0] - 2020-09-07
 

--- a/styles/css/product/extensions.account-dialog.css
+++ b/styles/css/product/extensions.account-dialog.css
@@ -40,10 +40,6 @@
   align-items: center;
 }
 
-.dialogInput :global(.vtex-input-prefix__group) {
-  border: 2px solid #CACBCC;
-}
-
 .dialogInput :global(.vtex-styleguide-9-x-input) {
   background-color: white;
 }


### PR DESCRIPTION
#### What problem is this solving?

This solves a problem in which the danger red border does not appear when the account modal input is indicating errors

#### How should this be manually tested?

1. Visit this [workspace](https://newartur--extensions.myvtex.com/vtex-hotjar/p)
2. Click on `Get App`
3. Fill the account input with a bad string, such as `asdkhfasl`
4. Confirm. When the error appears, a red border should appear around the account input

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/3827456/92425203-ecc77000-f15c-11ea-9ae4-fffa13f2a506.png)

#### Type of changes

- [x] Bug fix <!-- a non-breaking change which fixes an issue -->
- [ ] New feature <!-- a non-breaking change which adds functionality -->
- [ ] Breaking change <!-- fix or feature that would cause existing functionality to change -->
- [ ] Refactoring <!-- chores, refactors and overall reduction of technical debt -->
