### PR TITLE
Screenshots filter to show only desktop images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.27.0] - 2020-10-22
+## Changed 
+- screenshots filter to show only desktop images
 
 ## [0.27.0] - 2020-10-22
 ## Fixed 

--- a/store/blocks/product/blocks/appScreenshots.jsonc
+++ b/store/blocks/product/blocks/appScreenshots.jsonc
@@ -21,7 +21,7 @@
   "app-images-slider#screenshots": {
     "props": {
       "orderBy": "imageLabel",
-      "filterPattern": "screenshot",
+      "filterPattern": "screenshotDesktop",
       "sliderLayoutProps": {
         "itemsPerPage": {
           "desktop": 1,


### PR DESCRIPTION
#### What problem is this solving?

Screenshots filter to show only desktop images

#### How should this be manually tested?

[Workspace](https://pricenew--extensions.myvtex.com/cliqueretire-ebox/p)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).



#### Type of changes

- [ ] Bug fix <!-- a non-breaking change which fixes an issue -->
- [x] New feature <!-- a non-breaking change which adds functionality -->
- [ ] Breaking change <!-- fix or feature that would cause existing functionality to change -->
- [ ] Refactoring <!-- chores, refactors and overall reduction of technical debt -->
