### PR TITLE
Fix duplicated categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Duplicated categories on the `all apps` page.
 
 ## [0.31.0] - 2021-01-27
 ### Added

--- a/store/blocks/all-apps/blocks/categories.json
+++ b/store/blocks/all-apps/blocks/categories.json
@@ -51,7 +51,7 @@
         "skusFilter": "FIRST_AVAILABLE"
       }
     },
-    "blocks": ["search-result-layout.desktop#marketing"]
+    "blocks": ["search-result-layout.desktop#customerSupport"]
   },
   "search-result-layout.desktop#customerSupport": {
     "children": ["shelf-container#customerSupport"]
@@ -137,7 +137,7 @@
     "children": ["shelf-container#privacy"]
   },
   "shelf-container#privacy": {
-    "children": ["flex-layout.col#privacy"]
+    "children": ["flex-layout.row#privacy"]
   },
   "search-result-layout.customQuery#developer": {
     "props": {


### PR DESCRIPTION
#### What problem is this solving?

Fix duplicated categories on the `all-apps` page.
[App Store](https://apps.vtex.com/all-apps)

#### How should this be manually tested?

[Workspace](https://pedroallapps--extensions.myvtex.com/all-apps)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).


#### Type of changes

- [x] Bug fix <!-- a non-breaking change which fixes an issue -->
- [ ] New feature <!-- a non-breaking change which adds functionality -->
- [ ] Breaking change <!-- fix or feature that would cause existing functionality to change -->
- [ ] Refactoring <!-- chores, refactors and overall reduction of technical debt -->
