### PR TITLE
Require Billing Address manual input in the Payment Step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Always require billing address
+
+## [0.32.0] - 2021-02-08
+
+### Added
+
+- Store selector to the page header
+
 ## [0.35.0] - 2021-02-22
 ### Fixed
 - Fix min-height of order-form-loading page

--- a/react/package.json
+++ b/react/package.json
@@ -25,6 +25,8 @@
     "vtex.breadcrumb": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.breadcrumb@1.9.1/public/@types/vtex.breadcrumb",
     "vtex.carousel": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.carousel@2.12.1/public/@types/vtex.carousel",
     "vtex.checkout-cart": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-cart@0.33.0/public/@types/vtex.checkout-cart",
+    "vtex.app-store-price": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.app-store-price@1.1.0/public/@types/vtex.app-store-price",
+    "vtex.checkout-step-group": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-step-group@0.11.0/public/@types/vtex.checkout-step-group",
     "vtex.checkout-summary": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-summary@0.17.0/public/@types/vtex.checkout-summary",
     "vtex.condition-layout": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.condition-layout@1.4.0/public/@types/vtex.condition-layout",
     "vtex.flex-layout": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.flex-layout@0.15.2/public/@types/vtex.flex-layout",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4931,6 +4931,10 @@ verror@1.10.0:
   version "0.12.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.app-store-components@0.12.0/public/@types/vtex.app-store-components#6fe6fb5826887cc9e8a4c263dedfca842dee02f6"
 
+"vtex.app-store-price@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.app-store-price@1.1.0/public/@types/vtex.app-store-price":
+  version "1.1.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.app-store-price@1.1.0/public/@types/vtex.app-store-price#882561807e6094eef99f5d14a85fdc1180c4a634"
+
 "vtex.breadcrumb@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.breadcrumb@1.9.1/public/@types/vtex.breadcrumb":
   version "1.9.1"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.breadcrumb@1.9.1/public/@types/vtex.breadcrumb#015bac17938f439d0deb97236fa54f724165fb6b"
@@ -4942,6 +4946,10 @@ verror@1.10.0:
 "vtex.checkout-cart@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-cart@0.33.0/public/@types/vtex.checkout-cart":
   version "0.33.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-cart@0.33.0/public/@types/vtex.checkout-cart#0b713ce02dbcead8f4fe28640839e251a2755c8a"
+
+"vtex.checkout-step-group@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-step-group@0.11.0/public/@types/vtex.checkout-step-group":
+  version "0.11.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-step-group@0.11.0/public/@types/vtex.checkout-step-group#caae8acb3a3e3ef26eabbc2484409232db8bc414"
 
 "vtex.checkout-summary@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-summary@0.17.0/public/@types/vtex.checkout-summary":
   version "0.17.0"

--- a/store/blocks/checkout/index.jsonc
+++ b/store/blocks/checkout/index.jsonc
@@ -130,8 +130,13 @@
   },
   "checkout-step-group#app-store": {
     "children": [
-      "payment-step"
+      "payment-step#app-store"
     ]
+  },
+  "payment-step#app-store": {
+    "props": {
+      "billingAddressType": "new"
+    }
   },
   "app-terms-of-service#terms": {
     "props": {

--- a/styles/css/order-form-loading/vtex.flex-layout.css
+++ b/styles/css/order-form-loading/vtex.flex-layout.css
@@ -1,5 +1,5 @@
 .flexRow--orderFormLoading {
-  background-color: #FFF;
+  background-color: #fff;
   display: flex;
   align-items: center;
   height: 75vh;


### PR DESCRIPTION
#### What problem is this solving?

OBS: this follows https://github.com/vtex-apps/checkout-step-group/pull/22

Require manual input of billing address in the credit card payment step

#### How should this be manually tested?

1. Visit this linked [workspace](https://newartur--extensions.myvtex.com/vtex-sms-provider/p)
2. Click `Get App`
3. Provide a store name, e.g. `storecomponents`
4. When the login flow is done, you'll be able to edit payment options. Choose Credit Card
5. Notice that when extra data information is required, the billing address input form is always displayed

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

How this looks like:
![image](https://user-images.githubusercontent.com/3827456/108282402-4eeebd00-7160-11eb-8f3b-2b2d85b1a211.png)

#### Type of changes

- [ ] Bug fix <!-- a non-breaking change which fixes an issue -->
- [x] New feature <!-- a non-breaking change which adds functionality -->
- [ ] Breaking change <!-- fix or feature that would cause existing functionality to change -->
- [ ] Refactoring <!-- chores, refactors and overall reduction of technical debt -->
