### PR TITLE
Add Conditional Get App according to user Sales Channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - App by Sales Channel page
+- Replace GET APP with "Conditional Get App by Sales Channel" component
 
 ## [0.32.0] - 2021-02-08
 

--- a/react/package.json
+++ b/react/package.json
@@ -18,7 +18,7 @@
     "@vtex/test-tools": "^3.3.2",
     "@vtex/tsconfig": "^0.4.4",
     "apollo-cache-inmemory": "^1.6.5",
-    "extensions.account-dialog": "http://extensions.vtexassets.com/_v/public/typings/v1/extensions.account-dialog@0.8.0/public/@types/extensions.account-dialog",
+    "extensions.account-dialog": "http://extensions.vtexassets.com/_v/public/typings/v1/extensions.account-dialog@0.9.0/public/@types/extensions.account-dialog",
     "graphql": "^14.6.0",
     "typescript": "3.9.7",
     "vtex.app-store-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.app-store-components@0.12.0/public/@types/vtex.app-store-components",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -2419,9 +2419,9 @@ extend@~3.0.2:
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
-"extensions.account-dialog@http://extensions.vtexassets.com/_v/public/typings/v1/extensions.account-dialog@0.8.0/public/@types/extensions.account-dialog":
-  version "0.8.0"
-  resolved "http://extensions.vtexassets.com/_v/public/typings/v1/extensions.account-dialog@0.8.0/public/@types/extensions.account-dialog#115edd2e18ca92e430c04a5161c71954c11dfa0a"
+"extensions.account-dialog@http://extensions.vtexassets.com/_v/public/typings/v1/extensions.account-dialog@0.9.0/public/@types/extensions.account-dialog":
+  version "0.9.0"
+  resolved "http://extensions.vtexassets.com/_v/public/typings/v1/extensions.account-dialog@0.9.0/public/@types/extensions.account-dialog#0b4ab9fffa46520dd3614c372a0b4037ac196171"
 
 extglob@^2.0.4:
   version "2.0.4"

--- a/store/blocks/product/blocks/topBar.jsonc
+++ b/store/blocks/product/blocks/topBar.jsonc
@@ -114,7 +114,7 @@
       "colGap": 9
     },
     "children": [
-      "button-get-app"
+      "conditional-get-app-by-sales-channel"
     ]
   }
 }


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

GET APP button should redirect users to the appropriate page:

1) Admin install page (currently in production) if currency is `BRL`
2) order-form-loading flow else

#### How should this be manually tested?


First test:

1) Go to https://marlon--extensions.myvtex.com/

2) Select `BRL` currency in the Currency Selector

3) Click on "GET APP" for the `sms-provider` app: 

https://marlon--extensions.myvtex.com/vtex-sms-provider/p?

4) Make sure you're redirected to app's Admin page (https://storecomponents.myvtex.com/admin/apps/vtex.sms-provider/install)

Second Test:

1) Go to https://marlon--extensions.myvtex.com/

2) Select `USD` currency in the Currency Selector

3) Click on "GET APP" for the `cookiebotr` app: 

https://marlon--extensions.myvtex.com/vtex-cookiebot/p

4) Make sure you're redirected to `/checkout` (https://marlon--extensions.myvtex.com/checkout/#/payment)


Repeat both tests for mobile and tablet.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

- [ ] Bug fix <!-- a non-breaking change which fixes an issue -->
- [x] New feature <!-- a non-breaking change which adds functionality -->
- [ ] Breaking change <!-- fix or feature that would cause existing functionality to change -->
- [ ] Refactoring <!-- chores, refactors and overall reduction of technical debt -->
