### PR TITLE
Fix min-height of order-form-loading page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix min-height of order-form-loading page
 
 ## [0.34.0] - 2021-02-22
 ### Added

--- a/styles/css/order-form-loading/vtex.flex-layout.css
+++ b/styles/css/order-form-loading/vtex.flex-layout.css
@@ -2,5 +2,5 @@
   background-color: #FFF;
   display: flex;
   align-items: center;
-  height: 70vh;
+  height: 75vh;
 }


### PR DESCRIPTION
#### What problem is this solving?

Fix min-height of order-form-loading page

#### How should this be manually tested?

[Workspace](https://pedrocheckout--extensions.myvtex.com/checkout/?__bindingAddress=extensions.myvtex.com/#/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).


#### Type of changes

- [x] Bug fix <!-- a non-breaking change which fixes an issue -->
- [ ] New feature <!-- a non-breaking change which adds functionality -->
- [ ] Breaking change <!-- fix or feature that would cause existing functionality to change -->
- [ ] Refactoring <!-- chores, refactors and overall reduction of technical debt -->
