### PR TITLE
Hide credit card extra data message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Hide Extra Data message in payment step
+
 ## [0.35.1] - 2021-02-22
 ### Changed
 

--- a/styles/css/checkout/vtex.checkout-step-group.css
+++ b/styles/css/checkout/vtex.checkout-step-group.css
@@ -5,3 +5,7 @@
 .billingAddressSectionContainer {
   display: none;
 }
+
+.creditCardExtraDataMessage {
+  display: none;
+}


### PR DESCRIPTION
#### What problem is this solving?

Hide the Extra Data message in the Credit Card payment step

#### How should this be manually tested?

1. Visit [this workspace](https://artur--extensions.myvtex.com/order-tracker-101/p?__bindingAddress=extensions.myvtex.com/). Be sure you have the `USD` currency selected in the store header;
2. Click `GET APP` and follow the login flow;
3. At the end, you'll see a Credit Card payment option. Please select it and fill in the info needed
4. When you are presented with a `REVIEW PURCHASE` option, the component will show no content between CC information and the review button

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/3827456/111515626-c6991300-8731-11eb-84a9-edf885c9b422.png)

#### Type of changes

- [x] Bug fix <!-- a non-breaking change which fixes an issue -->
- [ ] New feature <!-- a non-breaking change which adds functionality -->
- [ ] Breaking change <!-- fix or feature that would cause existing functionality to change -->
- [ ] Refactoring <!-- chores, refactors and overall reduction of technical debt -->
