### PR TITLE
Create basic My Orders customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+
+- Some `My Orders` section, such as Addresses, and unnecessary info and actions
+
 ## [0.36.1] - 2021-05-17
 
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -61,7 +61,9 @@
     "vtex.checkout": "2.x",
     "vtex.checkout-cart": "0.x",
     "vtex.checkout-summary": "0.x",
-    "vtex.product-list": "0.x"
+    "vtex.product-list": "0.x",
+    "vtex.my-orders-app": "3.x",
+    "vtex.my-cards": "1.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/styles/css/account/vtex.my-account.css
+++ b/styles/css/account/vtex.my-account.css
@@ -1,0 +1,15 @@
+.passwordBoxContainer,
+.newsletterBoxContainer,
+.boxContainerFooter,
+.phoneNumberContainer,
+.genderContainer,
+.emailContainer,
+.lastNameSubContainer,
+.menuLink,
+.cancelBtn {
+  display: none;
+}
+
+.menuLinks > div :nth-child(2) {
+  display: none;
+}

--- a/styles/css/account/vtex.my-account.css
+++ b/styles/css/account/vtex.my-account.css
@@ -13,3 +13,7 @@
 .menuLinks > div :nth-child(2) {
   display: none;
 }
+
+.menuLinks :first-child[href="#/orders"]{
+  display: none;
+}

--- a/styles/css/account/vtex.my-cards.css
+++ b/styles/css/account/vtex.my-cards.css
@@ -1,0 +1,3 @@
+.newCardButton {
+  display: none;
+}

--- a/styles/css/account/vtex.my-orders-app.css
+++ b/styles/css/account/vtex.my-orders-app.css
@@ -1,0 +1,4 @@
+.reorderBtn,
+.detailsBtn {
+  display: none;
+}


### PR DESCRIPTION
#### What problem is this solving?

Many sections of the My Orders/Account section are unnecessary or allow for illegal actions in our architecture

Depends on: https://github.com/vtex/my-cards/pull/55

#### How should this be manually tested?

Visit [this linked workspace](https://newartur--extensions.myvtex.com/account?__bindingAddress=extensions.myvtex.com/#/profile). Once the login flow is done (choose either `extensions`, `lojadaju` or `vtexgame1`), you can access the My Orders section. See that some information is omitted

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/3827456/113216770-34296100-9253-11eb-8bfa-deade201726e.png)

#### Type of changes

- [ ] Bug fix <!-- a non-breaking change which fixes an issue -->
- [x] New feature <!-- a non-breaking change which adds functionality -->
- [ ] Breaking change <!-- fix or feature that would cause existing functionality to change -->
- [ ] Refactoring <!-- chores, refactors and overall reduction of technical debt -->
