### PR TITLE
Allow checkout for BRL purchases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- `Get App` button redirects to checkout in all sales channels
+
+### Removed
+
+- Native `Boleto Bancário` payment option
+
 ## [1.0.0] - 2021-05-18
 
 ### Added

--- a/store/blocks/product/blocks/mobile/index.jsonc
+++ b/store/blocks/product/blocks/mobile/index.jsonc
@@ -18,7 +18,7 @@
     },
     "children": [
       "flex-layout.row#productOverview",
-      "conditional-get-app-by-sales-channel",
+      "button-get-app",
       "flex-layout.col#specificationsMobile"
     ]
   },
@@ -86,10 +86,10 @@
     "children": [
       "vtex.store-components:product-name",
       "flex-layout.row#brand",
-      "conditional-get-app-by-sales-channel#pdpTablet"
+      "button-get-app#pdpTablet"
     ]
   },
-  "conditional-get-app-by-sales-channel#pdpTablet": {
+  "button-get-app#pdpTablet": {
     "props": {
       "blockClass": "pdpTablet"
     }

--- a/store/blocks/product/blocks/topBar.jsonc
+++ b/store/blocks/product/blocks/topBar.jsonc
@@ -115,7 +115,7 @@
     },
     "children": [
       "flex-layout.col#rating",
-      "conditional-get-app-by-sales-channel"
+      "button-get-app"
     ]
   },
   "flex-layout.col#rating": {

--- a/styles/css/checkout/vtex.checkout-step-group.css
+++ b/styles/css/checkout/vtex.checkout-step-group.css
@@ -9,3 +9,7 @@
 .creditCardExtraDataMessage {
   display: none;
 }
+
+.bankInvoiceOption {
+  display: none;
+}


### PR DESCRIPTION
#### What problem is this solving?

Provide Checkout functionality to app purchases in BRL

#### How should this be manually tested?

1. Visit this [workspace](https://appstorelogin--extensions.myvtex.com/);
2. Navigate to a BRL paid app, e.g. `Movile SMS`;
3. Click `Get App`. Provide `lojadaju` as an account name;
4. Log in to the store and you'll be returned to App Store's checkout; You should see two types of payment options:
    a) Credit Card (either saved and/or new)
    b) Boleto App Store

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/3827456/119394877-1e5f7780-bca9-11eb-85c4-c68d11968321.png)

#### Type of changes

- [ ] Bug fix <!-- a non-breaking change which fixes an issue -->
- [x] New feature <!-- a non-breaking change which adds functionality -->
- [ ] Breaking change <!-- fix or feature that would cause existing functionality to change -->
- [ ] Refactoring <!-- chores, refactors and overall reduction of technical debt -->
