### PR TITLE
Changes compatibility alert block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Chore
+- Uses compatibility alert from new app
 
 ## [1.5.0] - 2021-07-07
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -63,7 +63,8 @@
     "vtex.checkout-summary": "0.x",
     "vtex.product-list": "0.x",
     "vtex.my-orders-app": "3.x",
-    "vtex.my-cards": "1.x"
+    "vtex.my-cards": "1.x",
+    "vtex.app-store-compatibility-alert": "0.x"
   },
   "peerDependencies": {
     "vtex.reviews-and-ratings": "2.x"

--- a/store/blocks/checkout/index.jsonc
+++ b/store/blocks/checkout/index.jsonc
@@ -77,7 +77,7 @@
   "product-list-content-desktop": {
     "children": [
       "flex-layout.row#list-row.desktop",
-      "compatibility-alert#checkout"
+      "vtex.app-store-compatibility-alert:compatibility-alert#checkout"
     ]
   },
   "flex-layout.row#list-row.desktop": {
@@ -144,7 +144,7 @@
       "blockClass": "checkoutAppPrice"
     }
   },
-  "compatibility-alert#checkout": {
+  "vtex.app-store-compatibility-alert:compatibility-alert#checkout": {
     "props": {
       "blockClass": "checkoutCompatibilityAlert"
     }

--- a/store/blocks/product/blocks/mobile/index.jsonc
+++ b/store/blocks/product/blocks/mobile/index.jsonc
@@ -102,10 +102,10 @@
       "paddingBottom": 4
     }, 
     "children": [
-      "compatibility-alert#pdp"
+      "vtex.app-store-compatibility-alert:compatibility-alert#pdp"
     ]
   },
-  "compatibility-alert#pdp": {
+  "vtex.app-store-compatibility-alert:compatibility-alert#pdp": {
     "props": {
       "blockClass": "pdpCompatibilityAlert"
     }

--- a/store/blocks/product/index.jsonc
+++ b/store/blocks/product/index.jsonc
@@ -67,10 +67,10 @@
       "paddingBottom": 4
     }, 
     "children": [
-      "compatibility-alert"
+      "vtex.app-store-compatibility-alert:compatibility-alert"
     ]
   },
-  "compatibility-alert": {
+  "vtex.app-store-compatibility-alert:compatibility-alert": {
     "props": {
       "blockClass": "compatibility-alert"
     }


### PR DESCRIPTION
#### What problem is this solving?

Uses the compatibility alert from new app:  https://github.com/vtex/app-store-compatibility-alert
The new app will allow the admin to have the alert without adding `app-store-api` to the workspace.

Depends on: https://github.com/vtex/app-store-search/pull/18

#### How should this be manually tested?

[Workspace](http://fox3--extensions.myvtex.com/)

The compatibility alert should works as previously.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

- [ ] Bug fix <!-- a non-breaking change which fixes an issue -->
- [ ] New feature <!-- a non-breaking change which adds functionality -->
- [ ] Breaking change <!-- fix or feature that would cause existing functionality to change -->
- [ ] Refactoring <!-- chores, refactors and overall reduction of technical debt -->
