### PR TITLE
Remove breadcrumbs because of a bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.5.2] - 2021-07-22
+### Removed
+- Breadcrumbs from product details page
+
 ## [1.5.1] - 2021-07-13
 ### Chore
 - Uses compatibility alert from new app

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "extensions",
   "name": "appstoretheme",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "builders": {
     "assets": "0.x",
     "styles": "2.x",

--- a/store/blocks/product/index.jsonc
+++ b/store/blocks/product/index.jsonc
@@ -12,11 +12,6 @@
       "flex-layout.row#mainContainer"
     ]
   },
-  "breadcrumb#main": {
-    "props": {
-      "blockClass": "main"
-    }
-  },
   "flex-layout.row#mainContainer": {
     "props": {
       "horizontalAlign": "CENTER",
@@ -33,7 +28,6 @@
       "rowGap": 0
     },
     "children": [
-      "breadcrumb#main",
       "flex-layout.row#compatibility-alert",
       "flex-layout.row#pdp"
     ]

--- a/styles/css/product/vtex.flex-layout.css
+++ b/styles/css/product/vtex.flex-layout.css
@@ -13,6 +13,7 @@
 }
 
 .flexRow--mainContainer {
+  padding-top: 3.125rem;
   max-width: 90rem;
 }
 


### PR DESCRIPTION
#### What problem is this solving?

Breadcrumbs in our PDP had a bug because we don't use the original category tree from the store to compose/generate our category pages in the storefront (instead, we use custom queries based on this tree).

Since these breadcrumbs come from `store-components`, we'll probably need to open a PR there implementing our logic or create a custom component inside `app-store-components` based on the original one.

To avoid breaking our user experience until choosing the path and implementing the solution, I just removed the breadcrumbs from our PDP. I also checked the implementation for mobile and tablet versions.

#### How should this be manually tested?

[Workspace](https://testallan--extensions.myvtex.com/vtex-sms-provider/p)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/72519489/126689275-974599c7-9014-49a2-9a45-6fa767deee64.png)

#### Type of changes

- [x] Bug fix <!-- a non-breaking change which fixes an issue -->
- [ ] New feature <!-- a non-breaking change which adds functionality -->
- [ ] Breaking change <!-- fix or feature that would cause existing functionality to change -->
- [ ] Refactoring <!-- chores, refactors and overall reduction of technical debt -->
