### PR TITLE
Feat/checkout with cash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Changed
 - Removed credit card component and added custom buy app button to place orders with cash as a payment system (Phasing out VTEX Payment)
+- Removed payment method info from order placed page
 
 ## [1.5.3] - 2021-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Removed credit card component and added custom buy app button to place orders with cash as a payment system (Phasing out VTEX Payment)
 
 ## [1.5.3] - 2021-07-23
 

--- a/store/blocks/checkout/index.jsonc
+++ b/store/blocks/checkout/index.jsonc
@@ -32,35 +32,27 @@
   },
   "flex-layout.row#container-desktop": {
     "children": [
-      "flex-layout.col#checkout-desktop",
-      "flex-layout.col#items-summary-desktop"
+      "flex-layout.col#content-desktop"
     ],
-    "props": {
-      "blockClass": "checkoutContainer",
+    "props": {  
+      "preventHorizontalStretch": true,
+      "blockClass": "checkoutContainerAppStore",
       "preserveLayoutOnMobile": true,
-      "fullWidth": true
+      "horizontalAlign": "center"
     }
   },
-  "flex-layout.col#checkout-desktop": {
+  "flex-layout.col#content-desktop": {
     "children": [
-      "checkout-step-group#app-store",
-      "review-container#desktop",
-      "app-terms-of-service#terms"
-    ],
-    "props": {
-      "blockClass": "checkoutColumn",
-      "preventVerticalStretch": true,
-      "width": "60%"
-    }
+      "flex-layout.col#items-summary-desktop",
+      "flex-layout.col#container-cta"
+    ]
   },
   "flex-layout.col#items-summary-desktop": {
     "children": [
       "checkout-product-list",
-      "checkout-price#checkout",
-      "fee-charged-message"
+      "checkout-price#checkout"
     ],
     "props": {
-      "preventVerticalStretch": true,
       "blockClass": "checkoutSummaryDesktop"
     }
   },
@@ -105,6 +97,15 @@
       "rowGap": 3,
       "preserveLayoutOnMobile": true,
       "preventVerticalStretch": true
+    }
+  },
+  "flex-layout.col#container-cta": {
+    "children": [
+      "buy-app-button",
+      "app-terms-of-service#terms"
+    ],
+    "props": {
+      "horizontalAlign": "center"
     }
   },
   "flex-layout.row#container-mobile": {

--- a/store/blocks/checkout/index.jsonc
+++ b/store/blocks/checkout/index.jsonc
@@ -101,7 +101,7 @@
   },
   "flex-layout.col#container-cta": {
     "children": [
-      "buy-app-button",
+      "buy-app-button", // from vtex.app-store-components
       "app-terms-of-service#terms"
     ],
     "props": {
@@ -128,11 +128,6 @@
       "blockClass": "checkoutColumnMobile"
     }
   },
-  // "checkout-step-group#app-store": {
-  //   "children": [
-  //     "payment-step"
-  //   ]
-  // },
   "app-terms-of-service#terms": {
     "props": {
       "blockClass": "appTerms"

--- a/store/blocks/checkout/index.jsonc
+++ b/store/blocks/checkout/index.jsonc
@@ -43,17 +43,17 @@
   },
   "flex-layout.col#content-desktop": {
     "children": [
-      "flex-layout.col#items-summary-desktop",
+      "flex-layout.col#items-summary",
       "flex-layout.col#container-cta"
     ]
   },
-  "flex-layout.col#items-summary-desktop": {
+  "flex-layout.col#items-summary": {
     "children": [
       "checkout-product-list",
       "checkout-price#checkout"
     ],
     "props": {
-      "blockClass": "checkoutSummaryDesktop"
+      "blockClass": "checkoutItemsSummary"
     }
   },
   "checkout-product-list": {
@@ -120,21 +120,19 @@
   },
   "flex-layout.col#checkout-mobile": {
     "children": [
-      "checkout-step-group#app-store",
-      "checkout-price#checkout",
-      "review-container#mobile",
-      "app-terms-of-service#terms"
+      "flex-layout.col#items-summary",
+      "flex-layout.col#container-cta"
     ],
     "props": {
       "preventVerticalStretch": true,
       "blockClass": "checkoutColumnMobile"
     }
   },
-  "checkout-step-group#app-store": {
-    "children": [
-      "payment-step"
-    ]
-  },
+  // "checkout-step-group#app-store": {
+  //   "children": [
+  //     "payment-step"
+  //   ]
+  // },
   "app-terms-of-service#terms": {
     "props": {
       "blockClass": "appTerms"

--- a/store/blocks/order-placed/index.jsonc
+++ b/store/blocks/order-placed/index.jsonc
@@ -56,7 +56,6 @@
   "op-order": {
     "children": [
       "flex-layout.row#order-header",
-      "op-section#payments",
       "flex-layout.row#appSummary"
     ]
   },
@@ -97,15 +96,6 @@
   "responsive-layout.desktop#order-options-desktop": {
     "children": [
       "op-order-options"
-    ]
-  },
-  // payment section
-  "op-section#payments": {
-    "props": {
-      "name": "paymentMethods"
-    },
-    "children": [
-      "op-order-payment"
     ]
   }
 }

--- a/styles/css/checkout/vtex.flex-layout.css
+++ b/styles/css/checkout/vtex.flex-layout.css
@@ -22,7 +22,7 @@
 }
 
 
-.flexCol--checkoutSummaryDesktop {
+.flexCol--checkoutItemsSummary {
   margin: auto;
   height: fit-content;
   width: fit-content;

--- a/styles/css/checkout/vtex.flex-layout.css
+++ b/styles/css/checkout/vtex.flex-layout.css
@@ -23,12 +23,18 @@
 
 
 .flexCol--checkoutSummaryDesktop {
-  margin-left: 3rem;
+  margin: auto;
   height: fit-content;
   width: fit-content;
   border-radius: 0.5rem;
   padding: 1rem;
+  margin-bottom: 2rem;
 }
+
+.flexRow--checkoutContainerAppStore {
+  margin-top: 6rem;
+}
+
 
 :global(.vtex-input-prefix__group) :first-child {
   background-color: #fff;


### PR DESCRIPTION
#### What problem is this solving?

This code changes the UI in the checkout for the app store, removing the payment with credit card option and adding a custom button that places orders using cash as a payment system. This is a step to remove the dependency from Vtex Payment that has been deprecated.

This PR depends on the implementation for the custom `buy-app-button` from this [PR](https://github.com/vtex-apps/app-store-components/pull/35).

#### How should this be manually tested?

After adding an app in the cart in the [app store](https://apps.vtex.com/), change the URL to `https://apps.vtex.com/checkout?workspace=filacashpayment#/payment` and refresh the page. One should see the new checkout implementation.

#### Screenshots or example usage
_desktop view_
<img width="1440" alt="Screen Shot 2022-12-15 at 1 53 37 PM" src="https://user-images.githubusercontent.com/38737958/207923067-042c9148-945a-42e3-b080-e6e18ad098ae.png">

_mobile view_
<img width="375" alt="Screen Shot 2022-12-15 at 1 53 37 PM" src="https://user-images.githubusercontent.com/38737958/207923290-b1552287-eb35-4873-b896-5fba7032347c.png">

#### Type of changes

- [ ] Bug fix <!-- a non-breaking change which fixes an issue -->
- [ ] New feature <!-- a non-breaking change which adds functionality -->
- [ ] Breaking change <!-- fix or feature that would cause existing functionality to change -->
- [X] Refactoring <!-- chores, refactors and overall reduction of technical debt -->
